### PR TITLE
Proposal for a new guide for builders

### DIFF
--- a/builders.md
+++ b/builders.md
@@ -14,7 +14,7 @@ Here are the files containing the up to date list of rules to implement accordin
 
 - [Web rules](https://github.com/green-code-initiative/ecoCode/blob/main/docs/rules/README.md)
 - [Android (Java) rules](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/android-plugin/RULES.md)
-- [iOS (Swift) rulles](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/RULES.md)
+- [iOS (Swift) rules](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/RULES.md)
 
 
 Tasks are tracked via GitHub Kanban projects, with one task corresponding to one rule:

--- a/builders.md
+++ b/builders.md
@@ -1,13 +1,38 @@
-# ecoCode
+# Hello! Welcome to the builder team 👋
 
-# ecoCode Mobile
+Interested in adding rules to one of the ecoCode plugins? You are at the right place.\
+This guide will go through the **important elements** you might need for a successful challenge!
 
-Greetings to you, mobile developer.
+## 🎒 Starter pack
+
+Follow [this complete guide](starter-pack-challenge.md) to get ready before the challenge starts!\
+In case of difficulty or question about the installation procedure before the beginning of the challenge, you can [open a ticket here](https://github.com/green-code-initiative/ecoCode-common/issues).
 
 ## ✅ What's left to be done
 
-We keep the list of implemented versus non-implemented rules up to date. Take a look at the [remaining rules for the Android plugin](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/android-plugin/RULES.md) or the [remaining rules for the iOS plugin](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/RULES.md). You don't have enough? Go and give a hand to the [spotters team](spotters.md#ecocode-mobile).
+Here are the files containing the up to date list of rules to implement according to the chosen programming language:
+
+- [Web rules](https://github.com/green-code-initiative/ecoCode/blob/main/docs/rules/README.md)
+- [Android (Java) rules](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/android-plugin/RULES.md)
+- [iOS (Swift) rulles](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/RULES.md)
+
+
+Tasks are tracked via GitHub Kanban projects, with one task corresponding to one rule:
+
+- [Kaban for web rules](https://github.com/orgs/green-code-initiative/projects/1)
+- [Kaban for mobile rules](https://github.com/orgs/green-code-initiative/projects/4)
+
+You don't have enough rules? Go and give a hand to the [spotters team](spotters.md).
 
 ## 🚦 Contribute, but in the right way
 
-Code quality is very important in this complex project. Each plugin (Android, iOS) works differently and you have to learn their coding style. Take a look at the [contributing file for the iOS plugin](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/CONTRIBUTING.md) and the [contributing file for the Android plugin](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/android-plugin/CONTRIBUTING.md).
+It is best to first read the [common ecoCode contribution guide](https://github.com/green-code-initiative/ecoCode-common/blob/main/doc/CONTRIBUTING.md).\
+Code quality is very important in this complex project. Each plugin works differently and you have to learn their coding style.
+
+For some languages, there are specific contribution guidelines. Follow the guides for the languages you are interested in below:
+
+- Web: [JavaScript](https://github.com/green-code-initiative/ecoCode-linter/blob/main/eslint-plugin/CONTRIBUTING.md)
+- Mobile: [Android (Java)](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/android-plugin/CONTRIBUTING.md) • [iOS (Swift)](https://github.com/green-code-initiative/ecoCode-mobile/blob/main/ios-plugin/CONTRIBUTING.md)
+
+
+It's time for development, good luck builder! ⚒️


### PR DESCRIPTION
I thought that explaining web and mobile challenges at the same level could be more relevant as a large part of the guide is common to both. What do you think about it? Do you see any other elements to add to the guide?

[Here is the render of the formatted file](https://github.com/green-code-initiative/ecoCode-challenge/blob/utarwyn-patch-1/builders.md)